### PR TITLE
Support Python 3 and PostgreSQL 10

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ configparser==3.5.0
 decorator==4.0.10
 entrypoints==0.2.2
 enum34==1.1.6
-functools32==3.2.3.post2
+functools32==3.2.3.post2; python_version < '3'
 html5lib==0.9999999
 ipykernel==4.5.2
 ipython==5.1.0
@@ -31,7 +31,7 @@ pathlib2==2.1.0
 pexpect==4.2.1
 pickleshare==0.7.4
 prompt-toolkit==1.0.9
-psycopg2==2.6.2
+psycopg2==2.7.6.1
 ptyprocess==0.5.1
 Pygments==2.1.3
 python-dateutil==2.6.0


### PR DESCRIPTION
Using Python 3, `pip install -r requirements.txt` fails with the following error:

```
Collecting functools32==3.2.3.post2 (from -r requirements.txt (line 10))

(snip)

    This backport is for Python 2.7 only.

    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-build-q0uxt8_4/functools32/
```

Also, psycopg2 2.6.2 doesn't support PostgreSQL 10+:

```
Collecting psycopg2==2.6.2 (from -r requirements.txt (line 34))

(snip)

    Error: could not determine PostgreSQL version from '10.5'

    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-build-0w7zpqqx/psycopg2/
```

This PR fixes them.